### PR TITLE
KAN-47 캐릭터 데이터 파싱

### DIFF
--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cca722d77d38447980170eb362a93b13
+timeCreated: 1716981639

--- a/Assets/Resources/Data.meta
+++ b/Assets/Resources/Data.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fc4f8f4996d44c5586d0bd4b6482b3dd
+timeCreated: 1716981655

--- a/Assets/Resources/Data/Enemy.json
+++ b/Assets/Resources/Data/Enemy.json
@@ -1,0 +1,56 @@
+{
+  "enemy": [
+    {
+      "id": 2001,
+      "charName": "중입자",
+      "level": 1,
+      "hp": 80,
+      "speed": 83,
+      "attackStat": 21,
+      "shield": 30,
+      "elem": [
+        2,
+        4
+      ]
+    },
+    {
+      "id": 2002,
+      "charName": "반중입자",
+      "level": 1,
+      "hp": 80,
+      "speed": 83,
+      "attackStat": 21,
+      "shield": 30,
+      "elem": [
+        0,
+        5
+      ]
+    },
+    {
+      "id": 2003,
+      "charName": "허졸 변조자",
+      "level": 5,
+      "hp": 239,
+      "speed": 120,
+      "attackStat": 21,
+      "shield": 60,
+      "elem": [
+        4,
+        6
+      ]
+    },
+    {
+      "id": 2004,
+      "charName": "허졸 말살자",
+      "level": 5,
+      "hp": 279,
+      "speed": 100,
+      "attackStat": 21,
+      "shield": 60,
+      "elem": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/Assets/Resources/Data/Enemy.json.meta
+++ b/Assets/Resources/Data/Enemy.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa606a2ec2874054fbfa986769dc33c0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Data/Player.json
+++ b/Assets/Resources/Data/Player.json
@@ -1,0 +1,40 @@
+{
+  "player": [
+    {
+      "id": 1001,
+      "charName": "개척자",
+      "level": 1,
+      "hp": 168,
+      "speed": 95,
+      "attackStat": 81,
+      "elem": 1
+    },
+    {
+      "id": 1002,
+      "charName": "삼칠이",
+      "level": 1,
+      "hp": 144,
+      "speed": 101,
+      "attackStat": 69,
+      "elem": 2
+    },
+    {
+      "id": 1003,
+      "charName": "단항",
+      "level": 1,
+      "hp": 120,
+      "speed": 110,
+      "attackStat": 74,
+      "elem": 4
+    },
+    {
+      "id": 1004,
+      "charName": "히메코",
+      "level": 1,
+      "hp": 142,
+      "speed": 95,
+      "attackStat": 102,
+      "elem": 1
+    }
+  ]
+}

--- a/Assets/Resources/Data/Player.json.meta
+++ b/Assets/Resources/Data/Player.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d63aee95ee7cdc4a8c9b750035d7798
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/DataSample.unity
+++ b/Assets/Scenes/DataSample.unity
@@ -1,0 +1,581 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &6903121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6903126}
+  - component: {fileID: 6903125}
+  - component: {fileID: 6903124}
+  - component: {fileID: 6903123}
+  - component: {fileID: 6903122}
+  m_Layer: 0
+  m_Name: DataLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &6903122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6903121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af26f2e668f6487483ea0dd9325083ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerID: 1002
+  enemyID: 2002
+--- !u!65 &6903123
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6903121}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &6903124
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6903121}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &6903125
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6903121}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &6903126
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6903121}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.22, y: 0, z: 1.63}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &110004408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 110004413}
+  - component: {fileID: 110004412}
+  - component: {fileID: 110004411}
+  - component: {fileID: 110004410}
+  - component: {fileID: 110004409}
+  m_Layer: 0
+  m_Name: DataManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &110004409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110004408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08c4be2896444251a8d5cbcfa8dc7f43, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!65 &110004410
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110004408}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &110004411
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110004408}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &110004412
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110004408}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &110004413
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110004408}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.33, y: 0, z: -3.25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &803144209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 803144211}
+  - component: {fileID: 803144210}
+  - component: {fileID: 803144212}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &803144210
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803144209}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &803144211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803144209}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &803144212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803144209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!1 &1355640094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1355640097}
+  - component: {fileID: 1355640096}
+  - component: {fileID: 1355640095}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1355640095
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355640094}
+  m_Enabled: 1
+--- !u!20 &1355640096
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355640094}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1355640097
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355640094}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1355640097}
+  - {fileID: 803144211}
+  - {fileID: 110004413}
+  - {fileID: 6903126}

--- a/Assets/Scenes/DataSample.unity.meta
+++ b/Assets/Scenes/DataSample.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b1afa47a719e95d40ae28f163349888c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -2,9 +2,18 @@ using UnityEngine;
 
 public abstract class Character : MonoBehaviour
 {
-    public int hp;
+    public string charName;
+    public int level;
+    public int maxHP;
+    private int _hp;
     public int speed;
     public int attackStat;
+
+    public int HP
+    {
+        get => _hp;
+        set => _hp = Mathf.Clamp(value, 0, maxHP);
+    }
 
     public virtual void NormalAttack(Character target)
     {
@@ -13,6 +22,6 @@ public abstract class Character : MonoBehaviour
 
     public void GetDamage(int damage)
     {
-        hp -= damage;
+        HP -= damage;
     }
 }

--- a/Assets/Scripts/Custom.meta
+++ b/Assets/Scripts/Custom.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f16fa59f3adcd141a9b5cfb5d076f12
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Custom/DebugData.cs
+++ b/Assets/Scripts/Custom/DebugData.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using UnityEngine;
+
+public class DebugData : MonoBehaviour
+{
+    public int playerID = 1002;
+    public int enemyID = 2002;
+
+    private void Start()
+    {
+        var playerData = DataManager.Instance.GetPlayerData(playerID);
+        Debug.Log(JsonUtility.ToJson(playerData));
+        var enemyData = DataManager.Instance.GetEnemyData(enemyID);
+        Debug.Log(JsonUtility.ToJson(enemyData));
+    }
+}

--- a/Assets/Scripts/Custom/DebugData.cs.meta
+++ b/Assets/Scripts/Custom/DebugData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: af26f2e668f6487483ea0dd9325083ac
+timeCreated: 1716983097

--- a/Assets/Scripts/ElementType.cs
+++ b/Assets/Scripts/ElementType.cs
@@ -1,0 +1,4 @@
+﻿public enum ElementType
+{
+    Physical, Fire, Ice, Lightning, Wind, Quantum, Imaginary
+}

--- a/Assets/Scripts/ElementType.cs.meta
+++ b/Assets/Scripts/ElementType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 822a60c8e8b3410789a2510fe294ee2f
+timeCreated: 1716987147

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -2,6 +2,13 @@ using UnityEngine;
 
 public class Enemy : Character
 {
-    public int shield;
-    public ElementType[] weakElement;
+    private int _maxShield;
+
+    public int shield
+    {
+        get => _maxShield;
+        set => _maxShield = Mathf.Clamp(value, 0, _maxShield);
+    }
+
+    public ElementType[] weakElements;
 }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -2,5 +2,6 @@ using UnityEngine;
 
 public class Enemy : Character
 {
-
+    public int shield;
+    public ElementType[] weakElement;
 }

--- a/Assets/Scripts/Manager.meta
+++ b/Assets/Scripts/Manager.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6e1d99c039fc49408ecb1dae77edef97
+timeCreated: 1716981978

--- a/Assets/Scripts/Manager/DataManager.cs
+++ b/Assets/Scripts/Manager/DataManager.cs
@@ -14,7 +14,7 @@ public class DataManager : MonoBehaviour
     private Dictionary<int, Enemy> _enemies = new Dictionary<int, Enemy>();
     
     [System.Serializable]
-    public class Character
+    public class Character : System.IComparable<Character>
     {
         public int id;
         public string charName;
@@ -22,6 +22,11 @@ public class DataManager : MonoBehaviour
         public int hp;
         public int speed;
         public int attackStat;
+
+        public int CompareTo(Character other)
+        {
+            return other.speed - speed;
+        }
     }
     
     [System.Serializable]

--- a/Assets/Scripts/Manager/DataManager.cs
+++ b/Assets/Scripts/Manager/DataManager.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class DataManager : MonoBehaviour
+{
+    public static DataManager Instance;
+    
+    private const string DATA_PATH = "Data";
+    private const string PLAYER_JSON = "Player";
+    private const string ENEMY_JSON = "Enemy";
+
+    private Dictionary<int, Player> _players = new Dictionary<int, Player>();
+    private Dictionary<int, Enemy> _enemies = new Dictionary<int, Enemy>();
+    
+    [System.Serializable]
+    public class Character
+    {
+        public int id;
+        public string charName;
+        public int level;
+        public int hp;
+        public int speed;
+        public int attackStat;
+    }
+    
+    [System.Serializable]
+    public class Player : Character
+    {
+        public ElementType elem;
+    }
+    
+    [System.Serializable]
+    public class Enemy : Character
+    {
+        public int shield;
+        public ElementType[] elem;
+    }
+
+    private struct PlayerData
+    {
+        public Player[] player;
+    }
+
+    private struct EnemyData
+    {
+        public Enemy[] enemy;
+    }
+
+    private void InitPlayerData()
+    {
+        TextAsset playerJson = Resources.Load<TextAsset>(Path.Combine(DATA_PATH, PLAYER_JSON));
+        PlayerData playerList = JsonUtility.FromJson<PlayerData>(playerJson.text);
+
+        foreach (var data in playerList.player)
+        {
+            var player = data as Character;
+            _players.Add(data.id, data);
+        }
+    }
+
+    private void InitEnemyData()
+    {
+        TextAsset enemyJson = Resources.Load<TextAsset>(Path.Combine(DATA_PATH, ENEMY_JSON));
+        EnemyData enemyList = JsonUtility.FromJson<EnemyData>(enemyJson.text);
+
+        foreach (var data in enemyList.enemy)
+        {
+            var enemy = data as Character;
+            _enemies.Add(enemy.id, data);
+        }
+    }
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+        
+        InitPlayerData();
+        InitEnemyData();
+    }
+
+    public Player GetPlayerData(int id)
+    {
+        return _players[id];
+    }
+
+    public Enemy GetEnemyData(int id)
+    {
+        return _enemies[id];
+    }
+}

--- a/Assets/Scripts/Manager/DataManager.cs
+++ b/Assets/Scripts/Manager/DataManager.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class DataManager : MonoBehaviour
 {
-    public static DataManager Instance;
+    public static DataManager Instance { get; private set; }
     
     private const string DATA_PATH = "Data";
     private const string PLAYER_JSON = "Player";
@@ -82,6 +82,7 @@ public class DataManager : MonoBehaviour
             Destroy(gameObject);
         }
         
+        DontDestroyOnLoad(gameObject);
         InitPlayerData();
         InitEnemyData();
     }

--- a/Assets/Scripts/Manager/DataManager.cs.meta
+++ b/Assets/Scripts/Manager/DataManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 08c4be2896444251a8d5cbcfa8dc7f43
+timeCreated: 1716982159

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -2,5 +2,5 @@ using UnityEngine;
 
 public class Player : Character
 {
-    
+    public ElementType element;
 }


### PR DESCRIPTION
# 캐릭터 데이터 파싱

## 기능

Json 파일을 파싱하고 ID에 맞는 데이터를 반환하는 _데이터 매니저_ 추가


## 문제 해결

`JsonUtility`를 사용할 때 데이터를 넣어둘 클래스가 `MonoBehaviour`를 상속할 시, 파싱이 되지 않고 `null`이 뜨는 상황이 발생

> [!NOTE]
>
> 파싱한 데이터가 `null`로 뜰 경우 아래와 같이 `Serializable`을 통한 클래스 직렬화가 필요하며, `MonoBehaviour`의 상속을 받지 않는지 확인해야 함.

```c#
[System.Serializable]
    public class Character
    {
        public int id;
        public string charName;
        public int level;
        public int hp;
        public int speed;
        public int attackStat;
    }
``` 

## 참고 자료

- [유니티 공식 문서 - JsonUtility](https://docs.unity3d.com/ScriptReference/JsonUtility.html)