### PR TITLE
KAN-38-create-skill-dummy-data

### DIFF
--- a/Assets/Resources/Data/Skill.json
+++ b/Assets/Resources/Data/Skill.json
@@ -1,0 +1,112 @@
+{
+  "skill": [
+    {
+      "id": 1001001,
+      "name": "개척자 기본 공격",
+      "damageAttr1": [0.5, 0.7, 0.8, 0.9, 1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1001002,
+      "name": "개척자 스킬 공격",
+      "damageAttr1": [1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1002001,
+      "name": "삼칠이 기본 공격",
+      "damageAttr1": [0.5, 0.7, 0.8, 0.9, 1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1002002,
+      "name": "삼칠이 스킬 공격",
+      "damageAttr1": [1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1003001,
+      "name": "단항 기본 공격",
+      "damageAttr1": [0.5, 0.7, 0.8, 0.9, 1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1003002,
+      "name": "단항 스킬 공격",
+      "damageAttr1": [1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1004001,
+      "name": "히메코 기본 공격",
+      "damageAttr1": [0.5, 0.7, 0.8, 0.9, 1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 1004002,
+      "name": "히메코 스킬 공격",
+      "damageAttr1": [1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 2001001,
+      "name": "중입자 기본공격",
+      "damageAttr1": [1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 2002001,
+      "name": "반중입자 기본공격",
+      "damageAttr1": [1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 2003001,
+      "name": "허졸 변조자 기본공격",
+      "damageAttr1": [1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    },
+    {
+      "id": 2004001,
+      "name": "허졸 말살자 기본공격",
+      "damageAttr1": [1.0],
+      "damageAttr1Type": "attack",
+      "damageAttr2": [],
+      "damageAttr2Type": "none",
+      "range": "single"
+    }
+  ]
+}

--- a/Assets/Resources/Data/Skill.json.meta
+++ b/Assets/Resources/Data/Skill.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c46c1d50c3c7c84cbeaa9609aa0c4f4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 작업 요약
스킬에 대한 스키마와 스키마 기반 더미 데이터 추가
## 상세 내용
스킬의 스키마 형태는 아래와 같음.
```json
{
  "skill": [
    {
      "skill_id": 1001001,
      "name": "스킬 이름",
      "damageAttr1": [0.5, 0.7, 0.8, 0.9, 1.0],
      "damageAttr1Type": "none",
      "damageAttr2": [],
      "damageAttr2Type": "none",
      "range": "single"
    }
  ]
}
```

게임 기획상으로 스킬의 상세 인자 대한 갯수는 최대 2개로 지정되어 있으므로 damageAttr의 갯수는 2개까지로 지정
스킬 인자 타입은 첫번째 인자 이후로 없을 가능성이 있어 none 옵션으로 추가했으며 만약 none일 경우 damageAttr의 값은 빈 배열로 처리

### 스킬 인자 구조 (damageAttr)
스킬 ID 스키마 식별자 컨벤션은 `<캐릭터ID><스킬ID>` 형식으로 스킬 ID는 000 형태로 001부터 시작함.
이 예제를 적용하자면 개척자의 ID는 1001이고 일반 공격의 스킬은 첫번째 스킬이므로 1001001이 됨.

스킬 인자는 배열로 구성되어 있으며 배열의 길이는 최대 레벨임.
만약 스킬 인자 타입이 none인 경우 빈 배열로 제공

### 스킬 인자 타입 (damageAttrType) - enum
```
none = 없음, 
attack = 공격, 
heal = 체력회복,
taunt = 도발
```

### 스킬 범위 (range) - enum
```
single = 단일
single_friendly = 단일 아군
all = 전체
all_friendly = 전체 아군
```