### PR TITLE
Kan-45-battle finish UI

### DIFF
--- a/Assets/Scenes/TurnTestScene.unity
+++ b/Assets/Scenes/TurnTestScene.unity
@@ -3052,7 +3052,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 939537788}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -3061,8 +3061,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -469.3, y: 73}
-  m_SizeDelta: {x: -421.238, y: -159.7267}
+  m_AnchoredPosition: {x: -747, y: -0.0000066725}
+  m_SizeDelta: {x: -999.99, y: -500}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &939537791
 MonoBehaviour:
@@ -3119,10 +3119,10 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 1
+  m_ChildAlignment: 3
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+  m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0

--- a/Assets/Scenes/TurnTestScene.unity
+++ b/Assets/Scenes/TurnTestScene.unity
@@ -160,8 +160,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 7.5}
-  m_SizeDelta: {x: 0, y: -15}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &6085621
 MonoBehaviour:
@@ -176,7 +176,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1683,7 +1683,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -429, y: -308}
+  m_AnchoredPosition: {x: -402.5, y: -308}
   m_SizeDelta: {x: 191.2076, y: 48.0044}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &531410907
@@ -3735,7 +3735,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\uD50C\uB808\uC774\uC5B44"
+  m_Text: "\uD788\uBA54\uCF54"
 --- !u!222 &1071005434
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -5807,7 +5807,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -200, y: -327.51}
+  m_AnchoredPosition: {x: -169.4, y: -308}
   m_SizeDelta: {x: 191.2076, y: 48.0044}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1836952032
@@ -5843,7 +5843,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\uD50C\uB808\uC774\uC5B42"
+  m_Text: "\uC0BC\uCE60\uC774"
 --- !u!222 &1836952033
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -6540,7 +6540,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 48, y: -308}
+  m_AnchoredPosition: {x: 69.4, y: -310.5}
   m_SizeDelta: {x: 191.2076, y: 48.0044}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2095493968
@@ -6576,7 +6576,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\uD50C\uB808\uC774\uC5B43"
+  m_Text: "\uB2E8\uD56D"
 --- !u!222 &2095493969
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battle/BattleTurnManager.cs
+++ b/Assets/Scripts/Battle/BattleTurnManager.cs
@@ -125,13 +125,13 @@ public class BattleTurnManager : MonoBehaviour
             Debug.Log($"{toList[i].charName}은 {i}번 째이고 속도는 {toList[i].speed}이다.");
         }
         Debug.Log("-----------끝------------");
-        //for (int i = 0; i < toList.Count; i++)
-        //{
-        //    if(toList[i].hp == 0)
-        //    {
-        //        toList.Remove(toList[i]);
-        //    }
-        //}
+        for (int i = 0; i < toList.Count; i++)
+        {
+            if (toList[i].hp == 0)
+            {
+                toList.Remove(toList[i]);
+            }
+        }
         var sortedCharacters = toList.OrderByDescending(c => c.finalSpeed).ToList();
 
         uIManager.TurnTextClear();

--- a/Assets/Scripts/Battle/BattleTurnManager.cs
+++ b/Assets/Scripts/Battle/BattleTurnManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.TextCore.Text;
+using UnityEngine.UI;
 using static DataManager;
 
 [DefaultExecutionOrder(100)]
@@ -10,12 +11,12 @@ public class BattleTurnManager : MonoBehaviour
 {
     private bool isplayer;
     private int MaxRandom;
-    public List<GameObject> players; // 현재 플레이어 수
-    public List<GameObject> enemies; // 현재 몬스터 수
+    [SerializeField]private List<GameObject> players; // 현재 플레이어 수
+    [SerializeField]private List<GameObject> enemies; // 현재 몬스터 수
     Character turnPlayer;
-    public GameObject PlayerButton;
-    public GameObject basicTarget;
-    public GameObject healTarget;
+    [SerializeField]private GameObject PlayerButton;
+    [SerializeField]private GameObject basicTarget;
+    [SerializeField]private GameObject healTarget;
 
     [SerializeField]
     private Camera Camera;
@@ -118,6 +119,19 @@ public class BattleTurnManager : MonoBehaviour
     void SetTurnOrder()
     {
         List<Character> toList = queue.ToList();
+        Debug.Log("----------시작-------------");
+        for (int i = 0; i < toList.Count; i++)
+        {
+            Debug.Log($"{toList[i].charName}은 {i}번 째이고 속도는 {toList[i].speed}이다.");
+        }
+        Debug.Log("-----------끝------------");
+        //for (int i = 0; i < toList.Count; i++)
+        //{
+        //    if(toList[i].hp == 0)
+        //    {
+        //        toList.Remove(toList[i]);
+        //    }
+        //}
         var sortedCharacters = toList.OrderByDescending(c => c.finalSpeed).ToList();
 
         uIManager.TurnTextClear();
@@ -229,17 +243,13 @@ public class BattleTurnManager : MonoBehaviour
                     enemies[i].SetActive(false);
                 }
             }
-            turnPlayer.speed -= 100;
-            queue.Enqueue(turnPlayer);
-            SetTurnOrder();
-            p.ReturnPrevFinalSpeed();
-            
-
             Debug.Log($"광역공격 {turnPlayer.charName}");
         }
-        
+        turnPlayer.speed -= 100;
+        queue.Enqueue(turnPlayer);
+        SetTurnOrder();
+        p.ReturnPrevFinalSpeed();
         StartCoroutine(waitOneSec());
-
     }
     void MonsterAttack(Character turnMonster)
     {
@@ -308,6 +318,7 @@ public class BattleTurnManager : MonoBehaviour
         {
             isplayer = true;
             Debug.Log($"{turnPlayer.charName}의 차례");
+
         }
         else
         {
@@ -318,6 +329,7 @@ public class BattleTurnManager : MonoBehaviour
         if (isplayer)
         {
             PlayerButton.SetActive(true);
+            SetButtonName();
         }
         else
         {
@@ -338,4 +350,13 @@ public class BattleTurnManager : MonoBehaviour
         yield return new WaitForSeconds(1);
         Turn();
     }
+
+    public void SetButtonName()
+    {
+        Player playerButton = turnPlayer.GetComponent<Player>();
+        PlayerButton.GetComponentsInChildren<Text>()[0].text = playerButton.normalAttack.skillName;
+        PlayerButton.GetComponentsInChildren<Text>()[1].text = playerButton.battleSkill.skillName;
+    }
+
+
 }

--- a/Assets/Scripts/Battle/BattleTurnManager.cs
+++ b/Assets/Scripts/Battle/BattleTurnManager.cs
@@ -66,9 +66,6 @@ public class BattleTurnManager : MonoBehaviour
         {
             isCheckDie[i] = false;
         }
-
-        uIManager.FinishGame();
-
         Turn();
     }
     void Update()
@@ -137,11 +134,11 @@ public class BattleTurnManager : MonoBehaviour
     {
         Character turnPlayer1 = queue.Dequeue();
 
-        CheckDeadCharacter(turnPlayer1);
+        //CheckDeadCharacter(turnPlayer1);
 
         Character turnPlayer2 = queue.Dequeue();
 
-        CheckDeadCharacter(turnPlayer2);
+        //CheckDeadCharacter(turnPlayer2);
 
         int compSpeed = turnPlayer1.speed - turnPlayer2.speed;
 
@@ -233,12 +230,14 @@ public class BattleTurnManager : MonoBehaviour
                 }
             }
             turnPlayer.speed -= 100;
-            p.ReturnPrevFinalSpeed();
             queue.Enqueue(turnPlayer);
             SetTurnOrder();
+            p.ReturnPrevFinalSpeed();
+            
 
             Debug.Log($"광역공격 {turnPlayer.charName}");
         }
+        
         StartCoroutine(waitOneSec());
 
     }
@@ -265,7 +264,7 @@ public class BattleTurnManager : MonoBehaviour
         StartCoroutine(waitOneSec());
     }
 
-    private void CheckDeadChar()
+    private bool CheckDeadChar()
     {
         for (int i = 0; i < enemies.Count; i++)
         {
@@ -275,10 +274,8 @@ public class BattleTurnManager : MonoBehaviour
                 Debug.Log($"몬스터 죽은거 체크 {enemies[i].activeSelf}");
             }
         }
-        if(isCheckDie.All(x => x))
-        {
-            uIManager.FinishGame();
-        }
+
+        return isCheckDie.All(x => x);
     }
 
     public static bool isAllFalse(bool[] array)
@@ -289,20 +286,24 @@ public class BattleTurnManager : MonoBehaviour
 
     void Turn()
     {
-        CheckDeadChar();
+        if (CheckDeadChar())
+        {
+            uIManager.FinishGame();
+            return;
+        }
 
         SetTurnOrder();
 
-        turnPlayer = queue.Dequeue();
-        //if (queue.Count() > 0)
-        //{
-        //    CompareSpeed();
-        //}
-        //else
-        //{
-        //    Debug.Log("turn에 저장된 데이터가 없음");
-        //    return;
-        //}
+        //turnPlayer = queue.Dequeue();
+        if (queue.Count() > 0)
+        {
+            CompareSpeed();
+        }
+        else
+        {
+            Debug.Log("turn에 저장된 데이터가 없음");
+            return;
+        }
         if (turnPlayer is Player)
         {
             isplayer = true;

--- a/Assets/Scripts/Battle/PriorityQueue.cs
+++ b/Assets/Scripts/Battle/PriorityQueue.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 class PriorityQueue<T>
 {
@@ -59,6 +60,4 @@ class PriorityQueue<T>
     {
         queueList.Clear();
     }
-
-
 }

--- a/Assets/Scripts/Character/Character.cs
+++ b/Assets/Scripts/Character/Character.cs
@@ -81,4 +81,11 @@ public abstract class Character : MonoBehaviour, IComparable<Character>
     {
         OnTurnEnd?.Invoke();
     }
+
+    private void CorrectionSpeed()
+    {
+        int CorrectionValue = UnityEngine.Random.Range( 0, 5);
+
+
+    }
 }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -97,12 +97,12 @@ public class UIManager : MonoBehaviour
     {
         Debug.Log("InitItem");
         items = new Image[itemCount]; 
-        for (int i = 0; i < items.Length; i++)
+        for (int i = 0; i < itemCount; i++)
         {
             int itemNum = Random.Range(0, itemIndex.Length);
 
             items[i] = Instantiate(itemIndex[itemNum], ItemPanel.transform.position, Quaternion.identity);
-            items[i].transform.SetParent(ItemPanel.transform);
+            items[i].transform.SetParent(ItemPanel.transform); // ItemPanel = 전투결과창
             Debug.Log($"아이템{i} {items[i]}");
         }
     }


### PR DESCRIPTION
버그 내용
1. 속성이 일치하는 적을 선택했을 경우 해당 적의 예상 속도와 행동게이지에서의 속도가 다른 현상 발생
2. SkillDataManager.Range.all인 스킬 사용 시 hp가 0이 된 Enemy GameObject가 사라지지 않는 현상 발생

해결 방법
1. 우선 순위 큐를 toList로 복사하고 toList의 speed에 변화를 줘서 실제 우선순위 큐에는 영향이 없지만 행동게이지에는 예상 속도를 기준으로 정렬되게 구현하여 해결
2. 스킬 사용 후 필드의 Enemy들 중 hp가 0인 GameObject들을 모두 Active False 처리하여 해결