### PR TITLE
KAN-69-heal-item-structure

### DIFF
--- a/Assets/Resources/Data/Items.json
+++ b/Assets/Resources/Data/Items.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "id": 1,
+      "name": "Item 1",
+      "attributes": [
+        {
+          "itemType": 0,
+          "scope": 0,
+          "changeType": 1,
+          "value": 10
+        }
+      ]
+    }
+  ]
+}

--- a/Assets/Resources/Data/Items.json.meta
+++ b/Assets/Resources/Data/Items.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3cc426e1067ee49d781dfb4eb54f0311
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/BattleTurnManager.cs
+++ b/Assets/Scripts/Battle/BattleTurnManager.cs
@@ -68,6 +68,18 @@ public class BattleTurnManager : MonoBehaviour
             isCheckDie[i] = false;
         }
         Turn();
+
+        // 아이템 매니저 테스트용
+        ItemDataManager.Item item = ItemDataManager.Instance.GetItemData("1");
+        Debug.Log($"item name: {item.name}");
+        foreach (ItemDataManager.Attribute attribute in item.attributes)
+        {
+            Debug.Log($"attribute: {attribute.itemType}");
+            Debug.Log($"range: {attribute.scope}");
+            Debug.Log($"add type: {attribute.changeType}");
+            Debug.Log($"item value: {attribute.value}");
+        }
+        
     }
     void Update()
     {

--- a/Assets/Scripts/Manager/ItemDataManager.cs
+++ b/Assets/Scripts/Manager/ItemDataManager.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class ItemDataManager : MonoBehaviour
+{
+    static public ItemDataManager Instance { get; private set; }
+    public Dictionary<string, Item> ItemDataTable { get; private set; }
+
+    private const string DATA_PATH = "Data";
+    private const string ITEM_JSON = "Items";
+
+    public enum ItemType
+    {
+        heal,
+        exp
+    }
+
+    public enum Scope
+    {
+        single,
+        all
+    }
+
+    public enum ChangeType
+    {
+        point,
+        percent
+    }
+
+    [System.Serializable]
+    public class Attribute
+    {
+        public ItemType itemType;
+        public Scope scope;
+        public ChangeType changeType;
+        public int value;
+    }
+
+
+    [System.Serializable]
+    public class Item
+    {
+        public string id;
+        public string name;
+        public List<Attribute> attributes;
+    }
+
+    public class ItemData
+    {
+        public Item[] items;
+    }
+
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+
+        InitItemData();
+    }
+
+    private void InitItemData()
+    {
+        ItemDataTable = new();
+
+        TextAsset itemJson = Resources.Load<TextAsset>(Path.Combine(DATA_PATH, ITEM_JSON));
+        ItemData itemList = JsonUtility.FromJson<ItemData>(itemJson.text);
+
+
+        foreach (var data in itemList.items)
+        {
+            ItemDataTable.Add(data.id, data);
+        }
+    }
+
+    public Item GetItemData(string id)
+    {
+        return ItemDataTable[id];
+    }
+}

--- a/Assets/Scripts/Manager/ItemDataManager.cs.meta
+++ b/Assets/Scripts/Manager/ItemDataManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce40b78ca5d00484b8095890e09a0912
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 작업 요약
소모 아이템에 대한 데이터 추가

## 상세 내용
아이템 형식
```json
{
  "items": [
    {
      "id": 1, // 나중에 식별자 형식 지정
      "name": "Item 1", // 이름
      "attributes": [
        {
          "itemType": 0, // 0: heal, 1: exp
          "scope": 0, // 0: single, 1: all
          "changeType": 1, // 0: point, 1: percent
          "value": 10 // int
        }
      ]
    }
  ]
}
```
C# 클래스에서는 모두 enum으로 관리되며 JSON 에서만 숫자로 처리



아이템 불러오는 방식은 스킬매니저, 캐릭터와 동일하게 아래와 같은 코드를 적용하면 됨.
```csharp
// 아이템 매니저 테스트용
ItemDataManager.Item item = ItemDataManager.Instance.GetItemData("1");
Debug.Log($"item name: {item.name}");
foreach (ItemDataManager.Attribute attribute in item.attributes)
{
    Debug.Log($"attribute: {attribute.itemType}");
    Debug.Log($"range: {attribute.scope}");
    Debug.Log($"add type: {attribute.changeType}");
    Debug.Log($"item value: {attribute.value}");
}
```