### PR TITLE
KAN-67 키보드 조작을 위한 키 할당

### DIFF
--- a/Assets/Scripts/Battle/BattleCamera.cs
+++ b/Assets/Scripts/Battle/BattleCamera.cs
@@ -99,11 +99,11 @@ public class BattleCamera : MonoBehaviour
         _orbital.m_XAxis.Value = Mathf.Lerp(_lastXAxisValue, _targets[m_Enemy], (Time.time - _lastTime) / Duration);
     }
 
-    public void LookAt(Collider target)
+    public void LookAt(Transform target)
     {
         if (!_orbital) return;
         if (!target.CompareTag("Enemy")) return;
-        m_Enemy = target.transform;
+        m_Enemy = target;
         _lastXAxisValue = _orbital.m_XAxis.Value;
         _lastTime = Time.time;
     }

--- a/Assets/Scripts/Custom/DebugBattleCamera.cs
+++ b/Assets/Scripts/Custom/DebugBattleCamera.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Cinemachine;
 using UnityEngine;
 
@@ -15,11 +16,38 @@ public class DebugBattleCamera : MonoBehaviour
     public CinemachineVirtualCamera skillReady;
     public CinemachineVirtualCamera skillUse;
 
+    private PlayerInput _input;
+    private int _targetIndex = 0;
+
+    private void Awake()
+    {
+        _input = gameObject.AddComponent<PlayerInput>();
+        _input.OnNormalAttack += NormalReady;
+        _input.OnBattleSkill += SkillReady;
+    }
+
+    private void OnDestroy()
+    {
+        _input.OnNormalAttack -= NormalReady;
+        _input.OnBattleSkill -= SkillReady;
+    }
+
     private void Update()
     {
+        _input.ChangeIndex(enemies, ref _targetIndex);
+        cam.LookAt(enemies[_targetIndex].transform);
+        
         if (!Input.GetMouseButtonDown(0)) return;
         if (!Physics.Raycast(Camera.main.ScreenPointToRay(Input.mousePosition), out RaycastHit hit)) return;
-        cam.LookAt(hit.collider);
+
+        for (int i = 0; i < enemies.Length; i++)
+        {
+            if (hit.transform == enemies[i].transform)
+            {
+                _targetIndex = i;
+                break;
+            }
+        }
     }
 
     private void NormalReady()

--- a/Assets/Scripts/PlayerInput.cs
+++ b/Assets/Scripts/PlayerInput.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum KeyAction
+{
+    NormalAttack,
+    BattleSkill,
+    Sprint,
+    Interact
+}
+
+public class PlayerInput : MonoBehaviour
+{
+    private static Dictionary<KeyAction, KeyCode> _keys = new();
+
+    private KeyCode[] _defaultKeys =
+        { KeyCode.Q, KeyCode.E, KeyCode.LeftShift, KeyCode.F };
+
+    public Action OnNormalAttack;
+    public Action OnBattleSkill;
+
+    public bool Sprint => Input.GetKey(_keys[KeyAction.Sprint]) || Input.GetMouseButton(1);
+    public bool Interact => Input.GetKeyDown(_keys[KeyAction.Interact]);
+    public bool Confirm => Input.GetButtonDown("Submit");
+    public bool Cancel => Input.GetButtonDown("Cancel");
+
+    public Vector3 Axis
+    {
+        get
+        {
+            float h = Input.GetAxisRaw("Horizontal");
+            float v = Input.GetAxisRaw("Vertical");
+            return new Vector3(h, 0, v);
+        }
+    }
+
+    private void Awake()
+    {
+        for (int i = 0; i < Enum.GetValues(typeof(KeyAction)).Length; i++)
+        {
+            _keys.Add((KeyAction)i, _defaultKeys[i]);
+        }
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(_keys[KeyAction.NormalAttack]))
+        {
+            OnNormalAttack?.Invoke();
+        }
+
+        if (Input.GetKeyDown(_keys[KeyAction.BattleSkill]))
+        {
+            OnBattleSkill?.Invoke();
+        }
+    }
+
+    public void ChangeIndex<T>(T[] array, ref int index)
+    {
+        if (Input.GetButtonDown("Horizontal"))
+        {
+            index += (int)Axis.x;
+        }
+
+        index = Mathf.Clamp(index, 0, array.Length - 1);
+    }
+
+    public void ChangeKey(KeyAction key)
+    {
+        Event currentEvent = Event.current;
+        if (currentEvent.isKey) _keys[key] = currentEvent.keyCode;
+    }
+}

--- a/Assets/Scripts/PlayerInput.cs.meta
+++ b/Assets/Scripts/PlayerInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dac49eaede10b004e85d8d57834f047e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 키보드 조작 (턴 전투)

## 기능

키보드 `A`, `D` 를 눌러 대상의 배열의 인덱스 값을 수정하여 선택하는 대상이 바뀌도록 하였습니다.

```cs
// 사용_예시_1
// '_targetIndex'는 'enemies'라는 배열의 인덱스를 나타내는 정수입니다.

public Enemy[] enemies;
private int _targetIndex = 0;

private PlayerInput _input;

private void Awake()
{
    _input = gameObject.AddComponent<PlayerInput>();
    _input.OnNormalAttack += NormalReady;
    _input.OnBattleSkill += SkillReady;
}

private void Update()
{
    _input.ChangeIndex(enemies, ref _targetIndex);
    // '_targetIndex'가 아닌 '_currentIndex'라고 해도 될 것 같습니다.
}
```

또한 이벤트 호출을 통해 버튼과 같은 동작을 하도록 할 수 있습니다.

`Q`가 일반 공격, `E`는 전투 스킬이 동작하도록 키를 할당하였습니다.

```cs
// 사용_예시_2

private PlayerInput _input;

private void Awake()
{
    _input = gameObject.AddComponent<PlayerInput>();
    _input.OnNormalAttack += NormalReady;
    _input.OnBattleSkill += SkillReady;
}

private void NormalReady() { ... }
private void SkillReady() { ... }
```


## 기타 사항

키설정을 할 수 있도록 구현중입니다.



# 키보드 조작 (필드 이동)

이동, 상호작용 등 필드에서 사용할 수 있는 키를 할당하였습니다.