### PR TITLE
KAN-90 카메라 스크립트 수정 및 블렌딩 에셋 추가

### DIFF
--- a/Assets/Main Camera Blends.asset
+++ b/Assets/Main Camera Blends.asset
@@ -1,0 +1,70 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36baaa8bdcb9d8b49b9199833965d2c3, type: 3}
+  m_Name: Main Camera Blends
+  m_EditorClassIdentifier: 
+  m_CustomBlends:
+  - m_From: '**ANY CAMERA**'
+    m_To: Ready Camera
+    m_Blend:
+      m_Style: 0
+      m_Time: 2
+      m_CustomCurve:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 0
+        m_PostInfinity: 0
+        m_RotationOrder: 0
+  - m_From: '**ANY CAMERA**'
+    m_To: Attack Camera
+    m_Blend:
+      m_Style: 1
+      m_Time: 0.3
+      m_CustomCurve:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 0
+        m_PostInfinity: 0
+        m_RotationOrder: 0
+  - m_From: '**ANY CAMERA**'
+    m_To: Skill Camera
+    m_Blend:
+      m_Style: 1
+      m_Time: 0.3
+      m_CustomCurve:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 0
+        m_PostInfinity: 0
+        m_RotationOrder: 0
+  - m_From: '**ANY CAMERA**'
+    m_To: Hit Camera
+    m_Blend:
+      m_Style: 0
+      m_Time: 2
+      m_CustomCurve:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 0
+        m_PostInfinity: 0
+        m_RotationOrder: 0
+  - m_From: '**ANY CAMERA**'
+    m_To: Heal Camera
+    m_Blend:
+      m_Style: 0
+      m_Time: 2
+      m_CustomCurve:
+        serializedVersion: 2
+        m_Curve: []
+        m_PreInfinity: 0
+        m_PostInfinity: 0
+        m_RotationOrder: 0

--- a/Assets/Main Camera Blends.asset.meta
+++ b/Assets/Main Camera Blends.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36b65caf0a26ac94dbe930bea1ea7956
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/BattleCamera.cs
+++ b/Assets/Scripts/Battle/BattleCamera.cs
@@ -4,10 +4,8 @@ using UnityEngine;
 
 public class BattleCamera : MonoBehaviour
 {
-    private const float Duration = 0.2f;
+    private const float Duration = 0.3f;
 
-    public Transform startPosition;
-    public CinemachineVirtualCamera startCamera;
     public float startAngle = -50;
     public float eachAngle = 4;
 
@@ -75,17 +73,9 @@ public class BattleCamera : MonoBehaviour
     private float _lastTime;
     private float _lastXAxisValue;
 
-    private void Awake()
-    {
-        m_Camera = startCamera;
-    }
-
     private void Start()
     {
         UpdateEnemyList();
-
-        m_Player = startPosition;
-        m_Enemy = enemies[0].transform;
     }
 
     private void Update()
@@ -116,5 +106,12 @@ public class BattleCamera : MonoBehaviour
         {
             _targets.Add(enemies[i].transform, startAngle + i * eachAngle);
         }
+    }
+
+    public void SetCameraTo(CinemachineVirtualCamera camera, Transform follow, Transform lookAt)
+    {
+        m_Camera = camera;
+        m_Player = follow;
+        LookAt(lookAt);
     }
 }


### PR DESCRIPTION
# 카메라 블렌딩

카메라 블렌딩 에셋을 추가하였습니다.

## 사용법

1. 시네머신 브레인에 블렌딩 에셋을 추가합니다.

2. 가상 카메라 컴포넌트를 가지고 있는 게임 오브젝트의 이름을 블렌딩 에셋에 맞게 설정합니다.

3. 블렌딩이 이름에 맞는 카메라로 적용되는 모습을 확인합니다.